### PR TITLE
Add a .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
Git will never check-in or track changes to files match patterns in the .gitignore file. This is nice when you have local files that we don't really want or need to share with other people. Here, I've added .DS_Store to the file patterns to ignore. .DS_Store is an OSX file that caches information about a directory.
